### PR TITLE
Database initialization should be ON by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,4 @@ export FACTER_rt_fastcgi_port="9000"
 
 export FACTER_rt_setup_firewall=0
 export FACTER_rt_setup_cpan_modules=1
-export FACTER_rt_setup_initdb=0
+export FACTER_rt_setup_initdb=1


### PR DESCRIPTION
If initdb=0, then the database is not created or initialized, which
is very confusing on first run (install).  If initdb=1, then first
run is good, but the re-runs will fail due to the database already
being present.

For now, setting initdb=1 to avoid confusion for the first time
users.  Later (soon!) will add a check for the database presence and
some sane behavior.