### PR TITLE
Removed handling of SELinux

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,6 +28,5 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'puppetlabs-firewall'
 mod 'puppetlabs-vcsrepo'
 mod 'puppetlabs-mysql'
-mod 'ghoneycutt-selinux'
 mod 'meltwater-cpan',
 	:git => "https://github.com/meltwater/puppet-cpan"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,6 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    ghoneycutt-selinux (1.1.0)
-      puppetlabs-stdlib (>= 3.2.0)
     nanliu-staging (1.0.3)
     puppetlabs-firewall (1.4.0)
     puppetlabs-mysql (3.3.0)
@@ -19,7 +17,6 @@ GIT
     meltwater-cpan (1.0.0)
 
 DEPENDENCIES
-  ghoneycutt-selinux (>= 0)
   meltwater-cpan (>= 0)
   puppetlabs-firewall (>= 0)
   puppetlabs-mysql (>= 0)

--- a/manifests/000_base.pp
+++ b/manifests/000_base.pp
@@ -12,15 +12,6 @@ node default {
 		ip => '127.0.0.1',
 	}
 
-	class { 'selinux':
-		mode => 'disabled',
-	}
-
-	$packageHate = [
-		#'selinux-policy',
-		#'selinux-policy-targeted',
-	]
-
 	$packageLove = [
 		# Making life easy
 		'git',
@@ -44,8 +35,5 @@ node default {
 		ensure => 'latest',
 	}
 
-	package { $packageHate:
-		ensure => 'purged',
-	}
 }
 

--- a/manifests/150_rt.pp
+++ b/manifests/150_rt.pp
@@ -23,11 +23,6 @@ node default {
 		require => [ Group[$::rt_group], Package["nginx"] ],
 	}
 
-	$packageHate = [
-		#'selinux-policy',
-		#'selinux-policy-targeted',
-	]
-
 	$packageLove = [
 		# Things for building RT
 		'make',
@@ -49,10 +44,6 @@ node default {
 
 	package { $packageLove:
 		ensure => 'latest',
-	}
-
-	package { $packageHate:
-		ensure => 'purged',
 	}
 
 	service { 'nginx':


### PR DESCRIPTION
This functionality was not reliable anyway (required a reboot),
and it was confusing people who thought SELinux was disabled,
while it wasn't.

Installation instructions now make it a responsibility of the user
to disable or configure SELinux.